### PR TITLE
Updating sample modules that are not updated in prod

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ repository: https://github.com/SolaceSamples/solace-samples-amqp-qpid-jms2
 
 # Also see _includes/intro.html to customize the description which gets included in index.html.
 
-# Links
+# Config Links
 links-get-started-amqp: //dev.solace.com/get-started/amqp-tutorials/
 links-get-started-amqp-jms1-dev: //dev.solace.com/get-started/amqp-tutorials-jms-11/
 links-get-started-amqp-jms2-dev: //dev.solace.com/get-started/amqp-tutorials-jms-2/


### PR DESCRIPTION
In order to fix the issue where cloud.solace.com is missing features existent on the dev site, we need to force a Jenkins build to trigger.